### PR TITLE
fix SQL for compatibility

### DIFF
--- a/src/main/java/org/secverse/secVersEssentialsXMySQLConnector/helper/DBCommands.java
+++ b/src/main/java/org/secverse/secVersEssentialsXMySQLConnector/helper/DBCommands.java
@@ -12,14 +12,14 @@ public class DBCommands {
 
     public void upsertUser(UUID uuid, String name, double balance, String lastLoc, String homes, String group, long timestamp) throws SQLException {
         String sql = """
-            INSERT INTO essentials_users (uuid, name, balance, last_location, homes, group, synced, last_update)
+            INSERT INTO essentials_users (uuid, name, balance, last_location, homes, groupname, synced, last_update)
             VALUES (?, ?, ?, ?, ?, ?, TRUE, ?)
             ON DUPLICATE KEY UPDATE\s
                 name=VALUES(name),\s
                 balance=VALUES(balance),\s
                 last_location=VALUES(last_location),\s
                 homes=VALUES(homes),\s
-                group=VALUES(group),\s
+                groupname=VALUES(groupname),\s
                 synced=TRUE,
                 last_update=VALUES(last_update)""";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {

--- a/src/main/java/org/secverse/secVersEssentialsXMySQLConnector/helper/database.java
+++ b/src/main/java/org/secverse/secVersEssentialsXMySQLConnector/helper/database.java
@@ -40,7 +40,7 @@ public class database {
               uuid          CHAR(36) PRIMARY KEY,
               name          VARCHAR(32),
               balance       DOUBLE,
-              group         VARCHAR(64),
+              groupname     VARCHAR(64),
               last_location TEXT,
               homes         TEXT,
               synced        BOOLEAN DEFAULT TRUE,


### PR DESCRIPTION
On DB init, a SQL syntax error occured because of the column "group". Renaming it solves the issue.